### PR TITLE
ビューワーのインターフェースがドキュメント通りになっていなかったため修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ const viewer = toraViewer([
 // 次のページ(「設定: 読む方向」が「右から左」なら左のページ、「左から右」なら右のページ)
 viewer.goNext();
 // 前のページ(「設定: 読む方向」が「左から右」なら右のページ、「右から左」なら左のページ)
-viewer.goPrev();
+viewer.goBack(); // or viewer.goPrev();
 // 左のページに移動
 viewer.goLeft();
 // 右のページに移動
@@ -189,6 +189,8 @@ viewer.goRight();
 
 // 指定のIndexに移動(0始まりなので例の場合は3ページ目に移動)
 viewer.goTo(2);
+
+// 以下は v0.2.1 以降で利用可能
 
 // 設定を開く
 viewer.openSettings();

--- a/src/lib/components/main.tsx
+++ b/src/lib/components/main.tsx
@@ -23,6 +23,19 @@ export interface BaseProps {
   lastPageElement?: HTMLElement;
 }
 
+export interface PageControl {
+  readonly currentIndex: number;
+  readonly isLastPage: boolean;
+  goNext: () => void;
+  goBack: () => void;
+  goLeft: () => void;
+  goRight: () => void;
+  goTo: (index: number) => void;
+  openSettings: () => void;
+  closeSettings: () => void;
+  onCurrentIndexChanged: (handler: CurrentIndexChangeHandler) => void;
+}
+
 interface Props extends BaseProps {
   onDispose: () => void;
 }
@@ -32,7 +45,7 @@ type CurrentIndexChangeHandler = (index: number) => void;
 const FIRST_PAGE_SHOWN = 'viewer-first-page-shown';
 const LAST_PAGE_SHOWN = 'viewer-last-page-shown';
 
-export class Main extends ComponentBase {
+export class Main extends ComponentBase implements PageControl {
   /** コンテンツのページ一覧 */
   readonly pages: Page[];
   /** 空ページ(奇数ページで見開き表示時に表示させる) */

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -1,12 +1,12 @@
 export { type BaseProps } from './components/main';
-import { Main, type BaseProps } from './components/main';
+import { Main, type PageControl, type BaseProps } from './components/main';
 import { LoadablePageContent } from './interfaces/page-content';
 
 interface Props extends BaseProps {
   parent: Element;
 }
 
-export class Viewer {
+export class Viewer implements PageControl {
   #main: Main;
   #parentElement: Element;
   #current: Element;
@@ -84,6 +84,13 @@ export class Viewer {
     return this.#disposed;
   }
 
+  /**
+   * @see {@link Viewer#goBack}
+   */
+  goPrev() {
+    this.#main.goBack();
+  }
+
   goBack() {
     this.#main.goBack();
   }
@@ -102,6 +109,26 @@ export class Viewer {
 
   goTo(index: number) {
     this.#main.goTo(index);
+  }
+
+  get currentIndex() {
+    return this.#main.currentIndex;
+  }
+
+  get isLastPage() {
+    return this.#main.isLastPage;
+  }
+
+  openSettings() {
+    this.#main.openSettings();
+  }
+
+  closeSettings() {
+    this.#main.closeSettings();
+  }
+
+  onCurrentIndexChanged(handler: (index: number) => void) {
+    this.#main.onCurrentIndexChanged(handler);
   }
 
   dispose() {


### PR DESCRIPTION
呼び出せなかったプロパティ、メソッド
- goPrev()
    - goBack() と間違えて記述していたがこちらもエイリアスとして使えるようにする
- currentIndex
- isLastPage
- openSettings()
- closeSettings()
- onCurrentIndexChanged(handler)
