### PR TITLE
Canvasを使わず画像をそのまま表示するオプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ toraViewer([
   lastPageElement: document.getElementById('#last'),
   // 挿入する要素
   // 指定すると全画面表示ではなくなり、指定された要素に表示される。
-  insertTarget: document.getElementById('#embed')
+  insertTarget: document.getElementById('#embed'),
+  // 画像をそのまま表示する(画像の画質が悪くなる場合にお試しください。)
+  // v0.2.1 以降で利用可能
+  // デフォルト値: false
+  useRawImage: false,
 });
 ```
 

--- a/src/lib/@types/jsx.d.ts
+++ b/src/lib/@types/jsx.d.ts
@@ -47,8 +47,10 @@ declare namespace JSX {
   }
 
   interface ImgIntrinsicElement
-    extends DefaultIntrinsicElement<HTMLInputElement> {
+    extends DefaultIntrinsicElement<HTMLImageElement> {
     src: string;
+    width?: number;
+    height?: number;
     alt?: string;
   }
 

--- a/src/lib/components/main.tsx
+++ b/src/lib/components/main.tsx
@@ -20,6 +20,7 @@ export interface BaseProps {
   modal: boolean;
   title: string;
   controlShowTime: number;
+  useRawImage: boolean;
   lastPageElement?: HTMLElement;
 }
 
@@ -115,6 +116,7 @@ export class Main extends ComponentBase {
         new Page(content, {
           index,
           size: this.#props.pageSize,
+          pageType: this.#props.useRawImage ? 'image' : 'canvas',
           onTapLeft: () => this.goLeft(),
           onTapRight: () => this.goRight(),
         })

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -65,6 +65,7 @@ function normalizeOptions(options?: Options): BaseProps {
     modal,
     title: options?.title ?? '',
     controlShowTime: options?.controlShowTime ?? 3000,
+    useRawImage: options?.useRawImage ?? false,
     lastPageElement: options?.lastPageElement,
   };
 }


### PR DESCRIPTION
表示画像の画質が落ちる現象への対応のため
Canvasを使わず画像をそのまま表示するオプション(useRawImage)を追加する